### PR TITLE
Fix for ghc-9.4

### DIFF
--- a/hierarchical-clustering.cabal
+++ b/hierarchical-clustering.cabal
@@ -1,5 +1,5 @@
 Name:                hierarchical-clustering
-Version:             0.4.7
+Version:             0.4.7.1
 Synopsis:            Fast algorithms for single, average/UPGMA and complete linkage clustering.
 License:             BSD3
 License-file:        LICENSE

--- a/src/Data/Clustering/Hierarchical/Internal/Optimal.hs
+++ b/src/Data/Clustering/Hierarchical/Internal/Optimal.hs
@@ -180,7 +180,8 @@ clink xs dist = initPR n xs' >>= go 1
 buildDendrogram :: PointerRepresentation s a
                 -> ST s (Dendrogram a)
 buildDendrogram pr = do
-  (1,n) <- getBounds (lambda pr)
+  bounds <- getBounds (lambda pr)
+  let (1,n) = bounds
   lambdas <- getElems (lambda pr)
   pis     <- getElems (pi pr)
   let sorted = sortBy (\(_,l1,_) (_,l2,_) -> l1 `compare` l2) $

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
 # https://docs.haskellstack.org/en/stable/yaml_configuration/
-resolver: lts-13.27
+resolver: lts-21.0
 packages:
 - .


### PR DESCRIPTION
Work around `ST` no longer having a `MonadFail` instance.